### PR TITLE
Update Constants.java

### DIFF
--- a/PieOSXClient/src/Constants.java
+++ b/PieOSXClient/src/Constants.java
@@ -56,7 +56,6 @@ public class Constants {
         static final String ID = "id";
         static final String DATE = "date";
         static final String MSG = "msg";
-        c
         static final String SENDER = "sender";
         static final String IS_SENT = "isSent";
         static final String IS_READ = "isRead";


### PR DESCRIPTION
Removed unnecessary character from Constants.java (was causing compile failures.)